### PR TITLE
Feedback from aromatic-toast

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This Python package allows users to apply university-specific themes to altair p
 
 ### hueniversitypy in the Python ecosystem
 
-The hueniversitypy package fits into the Python ecosystem alongisde other Python packages that allow users to change the theme of plot objects. This package is different from others as it utilizes the altair visualization package rather than other types of visualization packages. Currently, there are very few packages in the Python ecosystem that apply themes to altair plots, as described in this [GitHub issue]( https://github.com/altair-viz/altair/issues/1333). One package that is designed to change the theme of altair plots for the Los Angeles Times publications can be found [here](https://github.com/datadesk/altair-latimes). Our package will be different as the goal of the change in plot theme is to adhere to certain university visual identities, rather than the Los Angeles Times colour theme.  
+The hueniversitypy package fits into the Python ecosystem alongside other Python packages that allow users to change the theme of plot objects. This package is different from others as it utilizes the altair visualization package rather than other types of visualization packages. Currently, there are very few packages in the Python ecosystem that apply themes to altair plots, as described in this [GitHub issue]( https://github.com/altair-viz/altair/issues/1333). One package that is designed to change the theme of altair plots for the Los Angeles Times publications can be found [here](https://github.com/datadesk/altair-latimes). Our package will be different as the goal of the change in plot theme is to adhere to certain university visual identities, rather than the Los Angeles Times colour theme.  
 
 ### Installation:
 

--- a/hueniversitypy/theme_alberta.py
+++ b/hueniversitypy/theme_alberta.py
@@ -2,7 +2,7 @@ def theme_alberta():
     """ 
     Applies a University of Alberta theme to all subsequential altair plot objects so they are displayed with the U of A visual identity.
     See the visual identity at https://www.ualberta.ca/toolkit/visual-identity/our-colours. 
-    Four palettes based on the U of A visual identity guidelines can be selected: 'alpha', 'beta', 'gamma' and 'delta'.
+    Four palettes based on the U of A visual identity guidelines can be selected: 'alpha', 'beta', 'gamma' and 'delta'. 
     See more details about the package on GitHub: https://github.com/UBC-MDS/hueniversitypy/blob/master/README.md 
 
 	

--- a/hueniversitypy/theme_alberta.py
+++ b/hueniversitypy/theme_alberta.py
@@ -3,6 +3,8 @@ def theme_alberta():
     Applies a University of Alberta theme to all subsequential altair plot objects so they are displayed with the U of A visual identity.
     See the visual identity at https://www.ualberta.ca/toolkit/visual-identity/our-colours. 
     Four palettes based on the U of A visual identity guidelines can be selected: 'alpha', 'beta', 'gamma' and 'delta'.
+    See more details about the package on GitHub: https://github.com/UBC-MDS/hueniversitypy/blob/master/README.md 
+
 	
     Returns
     -------
@@ -11,9 +13,14 @@ def theme_alberta():
 
     Example
     ----------
-    >>> alt.themes.register('theme_alberta', theme_alberta)
-    >>> alt.themes.enable('theme_alberta')
-
+    >>> from hueniversitypy.theme_alberta import *
+    >>> data = pandas.DataFrame({'X': numpy.random.randint(100, size=100), 
+                                'Y': numpy.random.randint(100, size=100), 
+                                'Cat': [['A', 'B', 'C'][numpy.random.randint(3, size=1)[0]] for i in range(100)]})
+    >>> scatterplot = (altair.Chart(data).mark_circle(size=60, opacity=0.5).encode(x='X', y='Y', color='Cat'))
+    >>> altair.themes.register("theme_alberta", theme_alberta)
+    >>> altair.themes.enable("theme_alberta")
+    >>> scatterplot
     """
 
     # Code attribution: Sergio Sanchez

--- a/hueniversitypy/theme_mcgill.py
+++ b/hueniversitypy/theme_mcgill.py
@@ -10,8 +10,14 @@ def theme_mcgill():
 
     Example
     ----------
+    >>> from hueniversitypy.theme_mcgill import *
+    >>> data = pandas.DataFrame({'X': numpy.random.randint(100, size=100), 
+                                'Y': numpy.random.randint(100, size=100), 
+                                'Cat': [['A', 'B', 'C'][numpy.random.randint(3, size=1)[0]] for i in range(100)]})
+    >>> scatterplot = (altair.Chart(data).mark_circle(size=60, opacity=0.5).encode(x='X', y='Y', color='Cat'))
     >>> alt.themes.register('theme_mcgill', theme_mcgill)
     >>> alt.themes.enable('theme_mcgill')
+    >>> scatterplot
     
     """
     # Code attribution: Sergio Sanchez

--- a/hueniversitypy/theme_mcgill.py
+++ b/hueniversitypy/theme_mcgill.py
@@ -1,7 +1,8 @@
 def theme_mcgill():
     """ 
     Applies McGill University's theme to all subsequential altair plot objects so they are displayed with the McGill visual identity.
-    See the visual identity at https://mcgill.ca/visual-identity/visual-identity-guide#mcgilllogo. The 
+    See the visual identity at https://mcgill.ca/visual-identity/visual-identity-guide#mcgilllogo. 
+    See more details about the package on GitHub: https://github.com/UBC-MDS/hueniversitypy/blob/master/README.md 
      
     Returns
     -------

--- a/hueniversitypy/theme_toronto.py
+++ b/hueniversitypy/theme_toronto.py
@@ -3,6 +3,8 @@ def theme_toronto():
     Applies a University of Toronto theme to all subsequential altair plot objects so they are displayed with the U of T visual identity. 
     See the visual identity at https://tinyurl.com/t3jjr49
     Three palettes based on the U of T visual identity guidelines can be selected: 'cool', 'vibrant' and 'awards'. 
+    See more details about the package on GitHub: https://github.com/UBC-MDS/hueniversitypy/blob/master/README.md 
+
 
 	
     Returns
@@ -20,7 +22,6 @@ def theme_toronto():
     >>> alt.themes.register('theme_toronto', theme_toronto)
     >>> alt.themes.enable('theme_toronto')
     >>> scatterplot
-
     """
     
     # Code attribution: Sergio Sanchez

--- a/hueniversitypy/theme_toronto.py
+++ b/hueniversitypy/theme_toronto.py
@@ -12,8 +12,14 @@ def theme_toronto():
 
     Example
     ----------
+    >>> from hueniversitypy.theme_toronto import *
+    >>> data = pandas.DataFrame({'X': numpy.random.randint(100, size=100), 
+                                'Y': numpy.random.randint(100, size=100), 
+                                'Cat': [['A', 'B', 'C'][numpy.random.randint(3, size=1)[0]] for i in range(100)]})
+    >>> scatterplot = (altair.Chart(data).mark_circle(size=60, opacity=0.5).encode(x='X', y='Y', color='Cat'))
     >>> alt.themes.register('theme_toronto', theme_toronto)
     >>> alt.themes.enable('theme_toronto')
+    >>> scatterplot
 
     """
     

--- a/hueniversitypy/theme_ubc.py
+++ b/hueniversitypy/theme_ubc.py
@@ -2,6 +2,7 @@ def theme_ubc():
     """ 
     Applies a University of British Columbia theme to all subsequential altair plot objects so they are displayed with the UBC visual identity. 
     See the visual identity at https://brand.ubc.ca/guidelines/downloads/ubc-colour-and-fonts/ 
+    See more details about the package on GitHub: https://github.com/UBC-MDS/hueniversitypy/blob/master/README.md 
 		
     Returns
     -------

--- a/hueniversitypy/theme_ubc.py
+++ b/hueniversitypy/theme_ubc.py
@@ -10,9 +10,14 @@ def theme_ubc():
 
     Example
     ----------
+    >>> from hueniversitypy.theme_ubc import *
+    >>> data = pandas.DataFrame({'X': numpy.random.randint(100, size=100), 
+                                'Y': numpy.random.randint(100, size=100), 
+                                'Cat': [['A', 'B', 'C'][numpy.random.randint(3, size=1)[0]] for i in range(100)]})
+    >>> scatterplot = (altair.Chart(data).mark_circle(size=60, opacity=0.5).encode(x='X', y='Y', color='Cat'))
     >>> alt.themes.register('theme_ubc', theme_ubc)
     >>> alt.themes.enable('theme_ubc')
-
+    >>> scatterplot
     """
     # Code attribution: Sergio Sanchez
     # https://towardsdatascience.com/consistently-beautiful-visualizations-with-altair-themes-c7f9f889602


### PR DESCRIPTION
Thoughts/suggestions from Lesley Miller & how I addressed it: 
1. It may be useful to a user to add test data and test plots in the example for every docstring. Then, a user may run an entire example from top to bottom and see the output instantly without visiting the package README. 
	- Fixed it. 
2. Under the `Documentation` section of the reviewer template it asks for Metadata. I wasn't able to check this off because I wasn't able to find this information if it exists. 
	- We have a [Contributors](https://github.com/UBC-MDS/hueniversitypy/blob/master/CONTRIBUTORS.md) file in the repo that contain our names & e-mail addresses. 
3. As I mentioned, I tested the package out on different datasets in addition to those in the README. I noticed that if a user makes a simple barchart of a single variable the color theme will not change. This seems reasonable since aesthetically there is no need to color every single bar a different color. The README barchart changes colors because it is plotting 2 different years. I'm not sure if a note about this behaviour should be included in the docstring just to alert users to this behavior if just in case this isn't what they are expecting. 
	- Thank you for pointing this out, but I would say a user might not find many things in our package that he is expecting. To convey this information to the user, I have included a link to the package README in the docstring. 
4. Since each theme is only 5-6 colors, plots that have more than this number of categories can not be uniquely identified by color. This isn't unique to your package as I've discovered this using other palette tools in the past. But perhaps this should be explicitly noted to the user? This is probably too nitpicky and I'm not even sure this is necessary since I've seen this issue before with other palettes in ggplot and no mention was made about this. 
	- This a valid concern a user might face when dealing with categories more than what the visual identity of a university provides. For this reason, we have added a link to the university's visual identity in the docstring of every function. 
5. Currently it seems the build is failing on both versions of Windows but this didn't effect me. 
    - I have noticed this too, and mainly it fails while uploading coverage report to Codecov. I don't think there is any other reason for it to fail. 
6. There is a tiny typo in the first line of the first paragraph in the README under `hueniversitypy in the Python ecosystem`. (the word `alongside` is misspelled)
	- Fixed it. 
